### PR TITLE
Fix duplicated join in RestauranteRepository

### DIFF
--- a/src/main/java/com/algaworks/algafood/domain/repository/RestauranteRepository.java
+++ b/src/main/java/com/algaworks/algafood/domain/repository/RestauranteRepository.java
@@ -14,7 +14,7 @@ public interface RestauranteRepository extends
         RestauranteRepositoryQueries,
         JpaSpecificationExecutor<Restaurante> {
 
-    @Query("from Restaurante r join r.cozinha join fetch r.cozinha")
+    @Query("from Restaurante r join fetch r.cozinha")
     List<Restaurante> findAll();
 
     List<Restaurante> findByTaxaFreteBetween(BigDecimal taxaInicial, BigDecimal taxaFinal);


### PR DESCRIPTION
## Summary
- simplify `findAll` query in `RestauranteRepository` to remove duplicated join

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842be876360832199738db58e8e7e18